### PR TITLE
managment page rewritten to use modal windows

### DIFF
--- a/api/fetchServerInfo.js
+++ b/api/fetchServerInfo.js
@@ -1,4 +1,3 @@
-import { alertClient } from "@/utils/alertClient"
 export const fetchServerInfo = async (server) => {
     try {
         const serverInfoResponse = await $fetch('http://localhost:4000/servers', {
@@ -7,7 +6,7 @@ export const fetchServerInfo = async (server) => {
         return serverInfoResponse.length ? serverInfoResponse[0] : null
     } catch (error) {
         console.error(error.message)
-        alertClient('Возникла ошибка при получении данных о сервере. Попробуйте позже')
+        return 503
     }
     
 }

--- a/api/updateServerInfo.js
+++ b/api/updateServerInfo.js
@@ -1,4 +1,3 @@
-import { alertClient } from '@/utils/alertClient'
 export const updateServerInfo = async (serverInfo) => {
     try {
         const {serverID, updatedInfo} = serverInfo
@@ -11,7 +10,6 @@ export const updateServerInfo = async (serverInfo) => {
         })
         return response
     } catch (err) {
-        alertClient('Обновление информации не удалось. Попробуйте позже')
         console.error(err)
         return 503
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-        <div class="flex align-middle h-screen">
+        <div class="flex align-middle h-screen mt-[-60px]">
             <div class="container mx-auto p-4 flex flex-col justify-center items-center text-center text-white">
                 <h2 class="font-bold text-2xl">Помощник администрации HASSLE ONLINE</h2>
                 <div>

--- a/utils/getServerInfo.js
+++ b/utils/getServerInfo.js
@@ -1,15 +1,13 @@
 import { validateUserAuthorization } from "@/utils/validateUserAuthorization"
 import { fetchServerInfo } from "@/api/fetchServerInfo"
-import { alertClient } from "@/utils/alertClient"
 export const getServerInfo = async (userAuthorizationInfo) => {
     const authorizationResponse = await validateUserAuthorization(userAuthorizationInfo)
     if (authorizationResponse) {
         const {serverID: server} = userAuthorizationInfo
         const serverInfo = await fetchServerInfo(server)
-        if (!serverInfo) {
-            alertClient('Неудалось получить информацию о сервере.')
+        if (!serverInfo || serverInfo === 503) {
             return null
         } return serverInfo 
-    } return null
+    } return 401
     
 }

--- a/utils/modifyServerInfo.js
+++ b/utils/modifyServerInfo.js
@@ -1,17 +1,12 @@
 import { validateUserAuthorization } from "@/utils/validateUserAuthorization"
-import { alertClient } from "@/utils/alertClient"
 import { updateServerInfo } from "@/api/updateServerInfo"
 export const modifyServerInfo = async (authorizationInfo, serverInfo) => {
     const authorizationResponse = await validateUserAuthorization(authorizationInfo)
     if (authorizationResponse) {
         const updateServerResponse = await updateServerInfo(serverInfo)
-        if (!updateServerResponse) {
-            alertClient('Обновление информации неудачно. Попробуйте позже')
-            return null
-        } else if (updateServerResponse === 503) {
-            return null
-        } return true
-        
-        }
+        return !updateServerResponse || updateServerResponse === 503
+        ? null
+        : updateServerResponse
+    }
     return null
 }

--- a/utils/validateUserAuthorization.js
+++ b/utils/validateUserAuthorization.js
@@ -1,11 +1,5 @@
 import { authenticateUser } from "@/utils/authenticateUser"
 export const validateUserAuthorization = async (authorizationInfo) => {
     const authorizationResponse = await authenticateUser(authorizationInfo)
-    if (!authorizationResponse) {
-        alertClient('Пройдите процедуру авторизации повторно') 
-        return null
-    } else if (authorizationResponse === 503) {
-        alertClient('Сервер не доступен. Невозможно проверить подлинность авторизации')
-        return null
-    } return true
+    return authorizationResponse || authorizationResponse !== 503
 }


### PR DESCRIPTION
managment page modal windows
changes in page: index.vue: due to default layout's padding, content was moving down to 60px, fixed with negative margin
changes in page: managment.vue: uses modal windows instead of alert's now
changes in api: fetchServerInfo.js: removed using alert due to switching to modal windows
changes in api: updateServerInfo.js: removed using alert due to switching to modal windows
changes in api: modifyServerInfo.js: removed alert + simplier error handling
changes in util: getServerInfo.js: removed alert, returning 401 if user is unathorized of authorization failed
changes in util: validateUserAuthorization.js: more clearer error handling