### PR TITLE
rate displaying with modal windows

### DIFF
--- a/api/fetchAdminInfo.js
+++ b/api/fetchAdminInfo.js
@@ -1,4 +1,3 @@
-import { alertClient } from "@/utils/alertClient"
 export const fetchAdminInfo = async (targetNickname) => {
     try {
         const response = await $fetch('http://localhost:4000/admins', {
@@ -6,9 +5,8 @@ export const fetchAdminInfo = async (targetNickname) => {
                 nickname: targetNickname
             }
         })
-        return response
+        return response.length ? response[0] : null
     } catch (err) {
-        alertClient('Получение информации с сервера неудачно. Попробуйте позже')
         console.error(err)
         return 503
     }

--- a/components/Statistics/StatisticsDayRate.vue
+++ b/components/Statistics/StatisticsDayRate.vue
@@ -16,7 +16,7 @@
                 <Icon v-if="isRateCompleted('time')" name="i-heroicons-check-20-solid" />
             </div>
         </template>
-        <AppErrorMessage v-else :message="'Не удалось получить информацию о норме'"/>
+        <AppErrorMessage v-else :message="'Данные о норме отсутвуют'"/>
     </div>
 </template>
 

--- a/components/Statistics/StatisticsDayRate.vue
+++ b/components/Statistics/StatisticsDayRate.vue
@@ -24,7 +24,7 @@
 const props = defineProps({
     rateInfo: {
         type: Object,
-        required: true,
+        required: true
     },
     serverInfo: {
         type: Object,
@@ -34,10 +34,10 @@ const props = defineProps({
 const {rateInfo, serverInfo} = toRefs(props)
 const serverLimits = reactive({})
 const minimumDailyRate = reactive({})
-if (serverInfo.value) {
-    serverLimits.value = serverInfo.value.allowedRate
-    minimumDailyRate.value = serverInfo.value.minimumDailyRate
-}
+watch(serverInfo, newValue => {
+    Object.assign(serverLimits, newValue.allowedRate)
+    Object.assign(minimumDailyRate, newValue.minimumDailyRate)
+}, {deep: true})
 const getLabel = (key) => {
   const labels = {
     pm: 'Ответов по репорту',
@@ -51,16 +51,16 @@ const getLabel = (key) => {
     
 }
 const isInfoAvailable = computed(() => {
-    return !!Object.keys(rateInfo.value).length && !!Object.keys(serverLimits.value).length 
+    return !!Object.keys(rateInfo.value).length && !!Object.keys(serverLimits).length 
 })
 function isRateAllowedToDisplay(key) {
-    return serverLimits.value && serverLimits.value[key]
+    return serverLimits && serverLimits[key]
 }
 const formattedTime = computed(() => formatDate(rateInfo.value.time))
 function isMinimumValueSpecified(rateName) {
-    return !!minimumDailyRate.value[rateName]
+    return !!minimumDailyRate[rateName]
 }
 function isRateCompleted(rateName) {
-    return isMinimumValueSpecified(rateName) ? rateInfo.value[rateName] >= minimumDailyRate.value[rateName] : false
+    return isMinimumValueSpecified(rateName) ? rateInfo.value[rateName] >= minimumDailyRate[rateName] : false
 }
 </script>

--- a/components/Statistics/StatisticsTableRate.vue
+++ b/components/Statistics/StatisticsTableRate.vue
@@ -8,9 +8,9 @@
             <thead>
                 <tr>
                     <th 
-                    v-for="rateName in displayedRates" 
-                    :key="rateName" 
-                    class="pr-3 border"
+                        v-for="rateName in displayedRates" 
+                        :key="rateName" 
+                        class="pr-3 border"
                     >
                     {{ rateName }}
                     </th>
@@ -19,10 +19,10 @@
             <tbody>
                 <tr v-for="day in filteredRateInfo" :key="day.id">
                     <td 
-                    v-for="rateName in displayedRates" 
-                    :key="rateName" 
-                    class="pr-3 border" 
-                    :class="paintBackgroundFromRateValue(day)"
+                        v-for="rateName in displayedRates" 
+                        :key="rateName" 
+                        class="pr-3 border" 
+                        :class="paintBackgroundFromRateValue(day)"
                     >
                     {{ displayRate(day, rateName) }}
                     </td>
@@ -48,16 +48,16 @@ const props = defineProps({
 const {serverInfo, rateInfo} = toRefs(props)
 const minimumDailyRate = reactive({})
 const allowedRate = reactive({})
-if (serverInfo.value) {
-    minimumDailyRate.value = serverInfo.value.minimumDailyRate
-    allowedRate.value = serverInfo.value.allowedRate
-} 
+watch(serverInfo, newValue => {
+    Object.assign(minimumDailyRate, newValue.minimumDailyRate)
+    Object.assign(allowedRate, newValue.allowedRate)
+})
 const isRateAvailable = computed(() => {
-    return !!(minimumDailyRate.value && allowedRate.value && rateInfo.value)
+    return !!(minimumDailyRate && allowedRate && rateInfo.value)
 })
 // показать все значения, которые разрешены для отображения
 const displayedRates = computed(() => {
-    return Object.keys(allowedRate.value).filter(rateName => allowedRate.value[rateName])
+    return Object.keys(allowedRate).filter(rateName => allowedRate[rateName])
 })
 // проверить разрешено ли отображать нужное значение
 const filteredRateInfo = computed(() => {
@@ -71,11 +71,11 @@ const filteredRateInfo = computed(() => {
 })
 // если время - отформатировать
 function displayRate(day, rateName){
-    return rateName !== 'time' ? day[rateName] : formatDate(day[rateName])
+    return rateName === 'time' ? formatDate(day[rateName]) : day[rateName]
 }
 // если все необходимые значение из объекта day больше или равно minimumDailyRate - применять зеленый бекграунд
 function paintBackgroundFromRateValue(day) {
-    const relevantRates = Object.keys(day).filter(rateName => Object.hasOwn(minimumDailyRate.value, rateName))
-    return relevantRates.every(rateName => day[rateName] >= minimumDailyRate.value[rateName]) ? 'bg-green-400' : 'bg-red-300'
+    const relevantRates = Object.keys(day).filter(rateName => Object.hasOwn(minimumDailyRate, rateName))
+    return relevantRates.every(rateName => day[rateName] >= minimumDailyRate[rateName]) ? 'bg-green-400' : 'bg-red-300'
 }
 </script>

--- a/components/Statistics/StatisticsTableRate.vue
+++ b/components/Statistics/StatisticsTableRate.vue
@@ -29,7 +29,7 @@
                 </tr>
             </tbody>
         </table>
-        <AppErrorMessage v-else :message="'Не удалось получить данные о норме'" />
+        <AppErrorMessage v-else :message="'Данные о норме отсутствуют'" />
     </div>
 </template>
 
@@ -51,8 +51,10 @@ const allowedRate = reactive({})
 watch(serverInfo, newValue => {
     Object.assign(minimumDailyRate, newValue.minimumDailyRate)
     Object.assign(allowedRate, newValue.allowedRate)
-})
+}, {deep: true})
 const isRateAvailable = computed(() => {
+    const ratesToCheck = [minimumDailyRate, allowedRate, rateInfo.value]
+    return ratesToCheck.every(obj => !!Object.keys(obj).length)
     return !!(minimumDailyRate && allowedRate && rateInfo.value)
 })
 // показать все значения, которые разрешены для отображения

--- a/pages/monitoring/[nick].vue
+++ b/pages/monitoring/[nick].vue
@@ -1,25 +1,31 @@
 <template>
-    <div v-if="isInfoAvailable" class="container px-4 pt-2 md:pt-4 mx-auto text-white">
-        <AppServerNumber class="py-2 md:pt-4"/>
-        <div>
-            <h2 class="font-bold text-2xl py-2 md:py-4">Администратор {{ nicknameWithoutUnderscore }}</h2>
-            <p class="text-lg">Уровень: {{ adminInfo.value.adminLvl }}</p>
-            <div class="md:flex">
-                <StatisticsDayRate 
-                    :rateInfo="todayRateInfo" 
-                    :serverInfo="serverInfo.value || {}"
-                    class="pr-4"
-                />
-                <StatisticsTableRate 
-                    :rateInfo="rateInfo" 
-                    :serverInfo="serverInfo.value || {}" 
-                />
+    <div class="container px-4 pt-2 md:pt-4 mx-auto text-white" >
+        <div v-if="isInfoAvailable" >
+            <AppServerNumber class="py-2 md:pt-4"/>
+            <div>
+                <h2 class="font-bold text-2xl py-2 md:py-4">Администратор {{ nicknameWithoutUnderscore }}</h2>
+                <p class="text-lg">Уровень: {{ adminInfo.adminLvl }}</p>
+                <div class="md:flex">
+                    <StatisticsDayRate 
+                        :rateInfo="todayRateInfo" 
+                        :serverInfo="serverInfo"
+                        class="pr-4"
+                    />
+                    <StatisticsTableRate 
+                        :rateInfo="rateInfo" 
+                        :serverInfo="serverInfo" 
+                    />
+                </div>
             </div>
         </div>
+        <div v-else>
+            <SearchWrongMessage v-if="!isRequestInProgress && !isRequestFailed" :role="'admin'" />
+        </div>
+        <UILoadingSpinner v-show="isRequestInProgress" />
+        <ModalServerError :isModalOpened="isRequestFailed" @closeModal="toggleWrongRequest" />
     </div>
-    <SearchWrongMessage v-else :role="'admin'" />
+    
 </template>
-
 <script setup>
 const mainStore = useMainAdminStore()
 const {nick} = useRoute().params
@@ -27,42 +33,69 @@ const authorizationInfo = reactive({
     nickname: mainStore.user.nickname,
     password: mainStore.user.password
 })
-const adminInfo = reactive({
-    value: await getAdminInfoFromServer()
-})
-const serverInfo = reactive({
-    value: await getServerInfoFromServer()
-})
-const isInfoAvailable = computed(() => {
-    return adminInfo.value && Object.keys(adminInfo.value).length
-})
-const nicknameWithoutUnderscore = computed(() => adminInfo.value?.nickname.split('_').join(' '))
-const rateInfo = computed(() => adminInfo.value?.rate)
+const adminInfo = reactive({})
+const serverInfo = reactive({})
+const isRequestInProgress = ref(false)
+const isRequestFailed = ref(false)
+
+const isInfoAvailable = computed(() => !!Object.keys(adminInfo).length)
+const nicknameWithoutUnderscore = computed(() => adminInfo.nickname.split('_').join(' '))
+const rateInfo = computed(() => adminInfo.rate)
 const todayRateInfo = computed(() => rateInfo.value[rateInfo.value.length - 1])
 
-if (adminInfo.value?.adminLvl === '1') {
-    serverInfo.value.minimumDailyRate = serverInfo.value.minimumDailyRate.helper
-    const allowedForHelpersRates = {
-        pm: serverInfo.value.allowedRate.pm,
-        z: serverInfo.value.allowedRate.z,
-        time: serverInfo.value.allowedRate.time
+onMounted(async () => {
+    await loadAdminInfo()
+    if (Object.keys(adminInfo).length) {
+        loadServerInfo()
     }
-    serverInfo.value.allowedRate = allowedForHelpersRates
-} else {
-    serverInfo.value.minimumDailyRate = serverInfo.value.minimumDailyRate.admin
+})
+
+function toggleWrongRequest(newValue = false) {
+    isRequestFailed.value = newValue
+    console.log(!newValue)
+    return !newValue ? navigateTo('/monitoring') : null
 }
 
-async function getAdminInfoFromServer() {
-    const responseAdminInfo = await getAdminInfo(nick, authorizationInfo)
-    if (responseAdminInfo) {
-        return responseAdminInfo
-    } 
+function toggleRequestInProgress(newValue = false) {
+    isRequestInProgress.value = newValue
 }
-async function getServerInfoFromServer() {
+
+async function loadAdminInfo() {
+    toggleRequestInProgress(true)
+    const responseAdminInfo = await getAdminInfo(nick, authorizationInfo)
+    console.log(responseAdminInfo)
+    if (responseAdminInfo && typeof responseAdminInfo !== 'number') {
+        Object.assign(adminInfo, JSON.parse(JSON.stringify(responseAdminInfo)))
+    } else if (typeof responseAdminInfo === 'number') {
+        toggleWrongRequest(true)
+    }
+    toggleRequestInProgress()
+}
+async function loadServerInfo() {
+    toggleRequestInProgress(true)
     const authData = {...authorizationInfo, serverID: mainStore.user.serverID}
     const responseServerInfo = await getServerInfo(authData)
-    if (responseServerInfo) {
-        return responseServerInfo
+    if (responseServerInfo && typeof responseServerInfo !== 'number') {
+        Object.assign(serverInfo, JSON.parse(JSON.stringify(responseServerInfo)))
+        modifyServerInfo()
+    } else if (typeof responseServerInfo === 'number'){
+        toggleWrongRequest(true)
+    }
+    toggleRequestInProgress()
+}
+
+function modifyServerInfo() {
+    if (adminInfo.adminLvl === '1') {
+    serverInfo.minimumDailyRate = serverInfo.minimumDailyRate.helper
+    const allowedForHelpersRates = {
+        pm: serverInfo.allowedRate.pm,
+        z: serverInfo.allowedRate.z,
+        time: serverInfo.allowedRate.time
+    }
+    serverInfo.allowedRate = allowedForHelpersRates
+    } else {
+        serverInfo.minimumDailyRate = serverInfo.minimumDailyRate.admin
     }
 }
-</script>
+
+</script>   

--- a/pages/monitoring/[nick].vue
+++ b/pages/monitoring/[nick].vue
@@ -40,8 +40,8 @@ const isRequestFailed = ref(false)
 
 const isInfoAvailable = computed(() => !!Object.keys(adminInfo).length)
 const nicknameWithoutUnderscore = computed(() => adminInfo.nickname.split('_').join(' '))
-const rateInfo = computed(() => adminInfo.rate)
-const todayRateInfo = computed(() => rateInfo.value[rateInfo.value.length - 1])
+const rateInfo = computed(() => adminInfo.rate || [])
+const todayRateInfo = computed(() => rateInfo.value[rateInfo.value.length - 1] || [])
 
 onMounted(async () => {
     await loadAdminInfo()
@@ -63,7 +63,6 @@ function toggleRequestInProgress(newValue = false) {
 async function loadAdminInfo() {
     toggleRequestInProgress(true)
     const responseAdminInfo = await getAdminInfo(nick, authorizationInfo)
-    console.log(responseAdminInfo)
     if (responseAdminInfo && typeof responseAdminInfo !== 'number') {
         Object.assign(adminInfo, JSON.parse(JSON.stringify(responseAdminInfo)))
     } else if (typeof responseAdminInfo === 'number') {

--- a/utils/getAdminInfo.js
+++ b/utils/getAdminInfo.js
@@ -1,16 +1,8 @@
 import { validateUserAuthorization } from "@/utils/validateUserAuthorization"
-import { alertClient } from "@/utils/alertClient"
 import { fetchAdminInfo } from "@/api/fetchAdminInfo"
-export const getAdminInfo = async(nickname, requester) => {
+export const getAdminInfo = async(targetNickname, requester) => {
     const authorizationResponse = await validateUserAuthorization(requester)
     if (authorizationResponse) {
-    const getAdminResponse = await fetchAdminInfo(nickname)
-    if (!getAdminResponse) {
-        alertClient('Получение информации об администраторе не удалось')
-        return null
-    } else if (getAdminResponse === 503) {
-        return null
-    } return getAdminResponse[0]
-    
-    } return null
+        return await fetchAdminInfo(targetNickname)
+    } return 401
 }

--- a/utils/getAdminInfo.js
+++ b/utils/getAdminInfo.js
@@ -2,7 +2,5 @@ import { validateUserAuthorization } from "@/utils/validateUserAuthorization"
 import { fetchAdminInfo } from "@/api/fetchAdminInfo"
 export const getAdminInfo = async(targetNickname, requester) => {
     const authorizationResponse = await validateUserAuthorization(requester)
-    if (authorizationResponse) {
-        return await fetchAdminInfo(targetNickname)
-    } return 401
+    return authorizationResponse ? await fetchAdminInfo(targetNickname) : 401 
 }

--- a/utils/getServerInfo.js
+++ b/utils/getServerInfo.js
@@ -4,10 +4,7 @@ export const getServerInfo = async (userAuthorizationInfo) => {
     const authorizationResponse = await validateUserAuthorization(userAuthorizationInfo)
     if (authorizationResponse) {
         const {serverID: server} = userAuthorizationInfo
-        const serverInfo = await fetchServerInfo(server)
-        if (!serverInfo || serverInfo === 503) {
-            return null
-        } return serverInfo 
+        return await fetchServerInfo(server)
     } return 401
     
 }


### PR DESCRIPTION
admin rate in monitoring is now displayed mith modal windows
changes in api: fetchAdminInfo.js: removed alert + response handling added
changes in component: Statistics/StatisticsDayRate.vue: correct using of reactive + allowed to see empty statistics of 5-6 lvl admins
changes in component: Statistics/StatisticsTableRate.vue: correct using of reactive + allowed to see empty statistics of 5-6 lvl admins
changes in page: monitoring/[nick].vue: correct server info fetching + errors handling with modal windows + correct using of reactive
changes in util: getAdminInfo.js: removed unnessecary response handling
changes in util: getServerInfo.js: removed unnessesary response handling
